### PR TITLE
Add books through API

### DIFF
--- a/backend/lib/bookwyrm/books.ex
+++ b/backend/lib/bookwyrm/books.ex
@@ -21,7 +21,7 @@ defmodule Bookwyrm.Books do
   end
 
   @doc """
-  Returns a list of all authors.
+  Returns a list of all authors that satisfy the given criteria.
   """
   def list_authors(criteria) do
     query = from(a in Author)
@@ -76,27 +76,26 @@ defmodule Bookwyrm.Books do
   @doc """
   Creates a book associated with the given list of authors.
   """
-  def create_book(attrs) do
+  def create_book(book_attrs, authors) do
     %Book{}
-    |> Book.changeset(attrs)
+    |> Book.changeset(book_attrs)
+    |> Ecto.Changeset.put_assoc(:authors, authors)
     |> Repo.insert()
   end
 
   @doc """
   Add a book to the current users list of books.
   """
-  def add_book(user, attrs) do
-    author = get_or_insert_author(attrs.author_name)
+  def add_book(user, book_attrs, author_attrs) do
+    author = get_or_insert_author(author_attrs)
 
-    create_book(attrs)
-    |> Ecto.Changeset.put_assoc(:author, author)
-    |> Ecto.Changeset.put_assoc(:user, user)
+    %Book{}
+    |> Book.changeset(book_attrs)
+    |> Ecto.Changeset.put_assoc(:authors, [author])
+    |> Ecto.Changeset.put_assoc(:users, [user])
     |> Repo.insert()
   end
 
-  @doc """
-  Get an author if it exists, or create one if it does not
-  """
   defp get_or_insert_author(attrs) do
     %Author{}
     |> Author.changeset(attrs)

--- a/backend/lib/bookwyrm/books.ex
+++ b/backend/lib/bookwyrm/books.ex
@@ -83,6 +83,27 @@ defmodule Bookwyrm.Books do
   end
 
   @doc """
+  Add a book to the current users list of books.
+  """
+  def add_book(user, attrs) do
+    author = get_or_insert_author(attrs.author_name)
+
+    create_book(attrs)
+    |> Ecto.Changeset.put_assoc(:author, author)
+    |> Ecto.Changeset.put_assoc(:user, user)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Get an author if it exists, or create one if it does not
+  """
+  defp get_or_insert_author(attrs) do
+    %Author{}
+    |> Author.changeset(attrs)
+    |> Repo.insert!(on_conflict: [set: [name: attrs.name]], conflict_target: :name)
+  end
+
+  @doc """
   Returns the review with the given `id`.
 
   Raises `Ecto.NoResultsError` if no booking was found.

--- a/backend/lib/bookwyrm/books/author.ex
+++ b/backend/lib/bookwyrm/books/author.ex
@@ -4,8 +4,7 @@ defmodule Bookwyrm.Books.Author do
   import Ecto.Query
 
   schema "authors" do
-    field(:first_name, :string)
-    field(:last_name, :string)
+    field(:name, :string)
     field(:slug, :string)
 
     many_to_many(:books, Bookwyrm.Books.Book, join_through: "authors_books")
@@ -14,11 +13,22 @@ defmodule Bookwyrm.Books.Author do
   end
 
   def changeset(author, attrs) do
-    required_fields = [:first_name, :last_name, :slug]
+    required_fields = [:name]
     optional_fields = []
 
     author
     |> cast(attrs, required_fields ++ optional_fields)
     |> validate_required(required_fields)
+    |> add_slug()
+  end
+
+  defp add_slug(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{name: name}} ->
+        put_change(changeset, :slug, Slugger.slugify_downcase(name))
+
+      _ ->
+        changeset
+    end
   end
 end

--- a/backend/lib/bookwyrm/books/author.ex
+++ b/backend/lib/bookwyrm/books/author.ex
@@ -20,6 +20,8 @@ defmodule Bookwyrm.Books.Author do
     |> cast(attrs, required_fields ++ optional_fields)
     |> validate_required(required_fields)
     |> add_slug()
+    |> unique_constraint(:name)
+    |> unique_constraint(:slug)
   end
 
   defp add_slug(changeset) do

--- a/backend/lib/bookwyrm/books/book.ex
+++ b/backend/lib/bookwyrm/books/book.ex
@@ -17,13 +17,24 @@ defmodule Bookwyrm.Books.Book do
   end
 
   def changeset(book, attrs) do
-    required_fields = [:title, :description, :isbn13, :slug]
+    required_fields = [:title, :description, :isbn13]
     optional_fields = []
 
     book
     |> cast(attrs, required_fields ++ optional_fields)
     |> validate_required(required_fields)
-    |> put_assoc(:authors, attrs.authors)
-    |> put_assoc(:users, attrs.users)
+    |> add_slug()
+    |> unique_constraint(:isbn13)
+    |> unique_constraint(:slug)
+  end
+
+  defp add_slug(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{title: title}} ->
+        put_change(changeset, :slug, Slugger.slugify_downcase(title))
+
+      _ ->
+        changeset
+    end
   end
 end

--- a/backend/lib/bookwyrm_web/resolvers/books.ex
+++ b/backend/lib/bookwyrm_web/resolvers/books.ex
@@ -28,7 +28,11 @@ defmodule BookwyrmWeb.Resolvers.Books do
   end
 
   def add_book(_, args, %{context: %{current_user: user}}) do
-    case Books.add_book(user, args) do
+    case Books.add_book(
+           user,
+           %{title: args.title, description: args.description, isbn13: args.isbn13},
+           %{name: args.author_name}
+         ) do
       {:error, changeset} ->
         {
           :error,

--- a/backend/lib/bookwyrm_web/resolvers/books.ex
+++ b/backend/lib/bookwyrm_web/resolvers/books.ex
@@ -32,7 +32,7 @@ defmodule BookwyrmWeb.Resolvers.Books do
       {:error, changeset} ->
         {
           :error,
-          message: "Could not create review!", details: ChangesetErrors.error_details(changeset)
+          message: "Could not add book!", details: ChangesetErrors.error_details(changeset)
         }
 
       {:ok, book} ->

--- a/backend/lib/bookwyrm_web/schema/schema.ex
+++ b/backend/lib/bookwyrm_web/schema/schema.ex
@@ -67,6 +67,17 @@ defmodule BookwyrmWeb.Schema.Schema do
 
       resolve(&Resolvers.Accounts.signin/3)
     end
+
+    @desc "Add a book to the current users list of books"
+    field :add_book, :book do
+      arg(:title, non_null(:string))
+      arg(:description, non_null(:string))
+      arg(:isbn13, non_null(:integer))
+      arg(:author_name, non_null(:string))
+
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.Books.add_book/3)
+    end
   end
 
   enum :sort_order do
@@ -87,8 +98,7 @@ defmodule BookwyrmWeb.Schema.Schema do
 
   object :author do
     field(:id, non_null(:id))
-    field(:first_name, non_null(:string))
-    field(:last_name, non_null(:string))
+    field(:name, non_null(:string))
     field(:slug, non_null(:string))
 
     field(:books, list_of(:book), resolve: dataloader(Books))

--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -45,7 +45,8 @@ defmodule Bookwyrm.MixProject do
       {:absinthe, "~> 1.4.0"},
       {:absinthe_plug, "~> 1.4.0"},
       {:absinthe_phoenix, "~> 1.4.0"},
-      {:dataloader, "~> 1.0.0"}
+      {:dataloader, "~> 1.0.0"},
+      {:slugger, "~> 0.3"}
     ]
   end
 

--- a/backend/mix.lock
+++ b/backend/mix.lock
@@ -23,5 +23,6 @@
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.15.1", "23ce3417de70f4c0e9e7419ad85bdabcc6860a6925fe2c6f3b1b5b1e8e47bf2f", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
+  "slugger": {:hex, :slugger, "0.3.0", "efc667ab99eee19a48913ccf3d038b1fb9f165fa4fbf093be898b8099e61b6ed", [:mix], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }

--- a/backend/priv/repo/migrations/20191230212638_create_authors.exs
+++ b/backend/priv/repo/migrations/20191230212638_create_authors.exs
@@ -3,13 +3,12 @@ defmodule Bookwyrm.Repo.Migrations.CreateAuthors do
 
   def change do
     create table(:authors) do
-      add(:first_name, :string, null: false)
-      add(:last_name, :string, null: false)
+      add(:name, :string, null: false)
       add(:slug, :string, null: false)
 
       timestamps()
     end
 
-    create unique_index(:authors, [:slug])
+    create(unique_index(:authors, [:slug]))
   end
 end

--- a/backend/priv/repo/migrations/20191230212638_create_authors.exs
+++ b/backend/priv/repo/migrations/20191230212638_create_authors.exs
@@ -9,6 +9,7 @@ defmodule Bookwyrm.Repo.Migrations.CreateAuthors do
       timestamps()
     end
 
+    create(unique_index(:authors, [:name]))
     create(unique_index(:authors, [:slug]))
   end
 end

--- a/backend/priv/repo/seeds.exs
+++ b/backend/priv/repo/seeds.exs
@@ -75,7 +75,6 @@ wise_mans_fear =
     title: "The Wise Man's Fear",
     description: "The Wise Man's Fear is a heroic fantasy novel.",
     isbn13: 9_780_756_404_734,
-    slug: "the-wise-mans-fear",
     authors: [
       rothfuss
     ],
@@ -112,7 +111,6 @@ foundation =
     title: "Foundation",
     description: "The first book in the Foundation Series.",
     isbn13: 1_234_567_890_123,
-    slug: "foundation",
     authors: [
       asimov
     ],
@@ -135,7 +133,6 @@ foundation_and_empire =
     title: "Foundation and Empire",
     description: "The second book in the Foundation Series.",
     isbn13: 2_234_567_890_123,
-    slug: "foundation-and-empire",
     authors: [
       asimov
     ],
@@ -158,7 +155,6 @@ second_foundation =
     title: "Second Foundation",
     description: "The third book in the Foundation Series.",
     isbn13: 3_234_567_890_123,
-    slug: "second-foundation",
     authors: [
       asimov
     ],
@@ -197,7 +193,6 @@ good_omens =
     title: "Good Omens",
     description: "A book about the birth of the son of Satan and the coming of the End Times.",
     isbn13: 4_234_567_890_123,
-    slug: "good-omens",
     authors: [
       gaiman,
       pratchett

--- a/backend/priv/repo/seeds.exs
+++ b/backend/priv/repo/seeds.exs
@@ -35,9 +35,7 @@ marina =
 rothfuss =
   %Author{}
   |> Author.changeset(%{
-    first_name: "Patrick",
-    last_name: "Rothfuss",
-    slug: "patrick-rothfuss",
+    name: "Patrick Rothfuss",
     books: []
   })
   |> Repo.insert!()
@@ -103,9 +101,7 @@ wise_mans_fear =
 asimov =
   %Author{}
   |> Author.changeset(%{
-    first_name: "Isaac",
-    last_name: "Asimov",
-    slug: "isaac-asimov",
+    name: "Isaac Asimov",
     books: []
   })
   |> Repo.insert!()
@@ -182,9 +178,7 @@ second_foundation =
 gaiman =
   %Author{}
   |> Author.changeset(%{
-    first_name: "Neil",
-    last_name: "Gaiman",
-    slug: "neil-gaiman",
+    name: "Neil Gaiman",
     books: []
   })
   |> Repo.insert!()
@@ -192,9 +186,7 @@ gaiman =
 pratchett =
   %Author{}
   |> Author.changeset(%{
-    first_name: "Terry",
-    last_name: "Pratchett",
-    slug: "terry-pratchett",
+    name: "Terry Pratchett",
     books: []
   })
   |> Repo.insert!()

--- a/backend/test/books/books_test.exs
+++ b/backend/test/books/books_test.exs
@@ -14,7 +14,7 @@ defmodule Bookwyrm.BooksTest do
     test "returns all of the authors" do
       _author_one = author_fixture()
       _author_two = author_fixture()
-      assert length(Books.list_authors()) == 2
+      assert length(Books.list_authors(%{})) == 6
     end
   end
 
@@ -22,13 +22,10 @@ defmodule Bookwyrm.BooksTest do
     test "creates an author with the correct information" do
       {:ok, author} =
         Books.create_author(%{
-          first_name: "Frank",
-          last_name: "Herbert",
-          slug: "frank-herbert"
+          name: "Frank Herbert"
         })
 
-      assert author.first_name == "Frank"
-      assert author.last_name == "Herbert"
+      assert author.name == "Frank Herbert"
       assert author.slug == "frank-herbert"
     end
   end
@@ -46,13 +43,15 @@ defmodule Bookwyrm.BooksTest do
       author = author_fixture()
 
       {:ok, book} =
-        Books.create_book(%{
-          title: "Testing",
-          description: "A book for testing",
-          isbn13: 1_234_567_890_123,
-          slug: "testing",
-          authors: [author]
-        })
+        Books.create_book(
+          %{
+            title: "Testing",
+            description: "A book for testing",
+            isbn13: 1_234_567_890_123,
+            slug: "testing"
+          },
+          [author]
+        )
 
       assert book.title == "Testing"
       assert book.description == "A book for testing"
@@ -82,6 +81,28 @@ defmodule Bookwyrm.BooksTest do
       {:ok, review} = Books.create_review(user, book, %{review: "So good.", rating: 5})
       assert review.user == user
       assert review.book == book
+    end
+  end
+
+  describe "add_book/2" do
+    test "creates a book and author, then associates the book to the given user" do
+      user = user_fixture()
+
+      book = %{
+        title: "Mort",
+        description: "A book about death.",
+        isbn13: 9_780_575_041_714
+      }
+
+      author = %{
+        name: "Terry Pratchett"
+      }
+
+      {:ok, mort} = Books.add_book(user, book, author)
+
+      user = Repo.preload(user, :books)
+
+      assert Enum.member?(Enum.map(mort.users, & &1.id), user.id)
     end
   end
 end

--- a/backend/test/support/test_helpers.ex
+++ b/backend/test/support/test_helpers.ex
@@ -25,10 +25,9 @@ defmodule Bookwyrm.TestHelpers do
 
     attrs =
       Enum.into(attrs, %{
-        username: "test-user",
+        username: attrs[:username] || "test-user",
         email: attrs[:email] || "#{username}@example.com",
-        password: attrs[:password] || "supersecret",
-        books: []
+        password: attrs[:password] || "supersecret"
       })
 
     {:ok, user} =
@@ -40,15 +39,11 @@ defmodule Bookwyrm.TestHelpers do
   end
 
   def author_fixture(attrs \\ %{}, books \\ []) do
-    first_name = "first_name-#{System.unique_integer([:positive])}"
-    last_name = "last_name-#{System.unique_integer([:positive])}"
-    slug = "slug-#{System.unique_integer([:positive])}"
+    name = "name-#{System.unique_integer([:positive])}"
 
     attrs =
       Enum.into(attrs, %{
-        first_name: attrs[:first_name] || first_name,
-        last_name: attrs[:last_name] || last_name,
-        slug: attrs[:slug] || slug,
+        name: attrs[:name] || name,
         books: books
       })
 
@@ -64,15 +59,13 @@ defmodule Bookwyrm.TestHelpers do
   def book_fixture(author \\ %Author{}, attrs \\ %{}) do
     title = "title-#{System.unique_integer([:positive])}"
     description = "description-#{System.unique_integer([:positive])}"
-    slug = "slug-#{System.unique_integer([:positive])}"
-    isbn13 = 1_234_567_890_123
+    isbn13 = System.unique_integer([:positive])
 
     attrs =
       Enum.into(attrs, %{
         title: attrs[:title] || title,
         description: attrs[:description] || description,
         isbn13: attrs[:isbn13] || isbn13,
-        slug: attrs[:slug] || slug,
         authors: [author]
       })
 


### PR DESCRIPTION
Add the ability to add books through a GraphQL mutation. These books will be added to the current users list of books. Accessing this mutation requires an authentication token.